### PR TITLE
Add a parameter to "computeMavenCentralUrl"

### DIFF
--- a/src/main/java/fr/jmini/utils/ecentral/ECentralTask.java
+++ b/src/main/java/fr/jmini/utils/ecentral/ECentralTask.java
@@ -272,11 +272,15 @@ public class ECentralTask {
     }
 
     static String computeMavenCentralUrl(MavenArtifact artifact) {
+        return computeMavenCentralUrl(artifact, ".jar");
+    }
+
+    static String computeMavenCentralUrl(MavenArtifact artifact, String extension) {
         // See https://github.com/eclipse/aether-core/blob/aether-0.9.1.v20140329/aether-util/src/main/java/org/eclipse/aether/util/repository/layout/MavenDefaultLayout.java#L42
 
         StringBuilder sb = new StringBuilder();
         sb.append("https://repo1.maven.org/maven2/");
-        sb.append(subPathInMavenRepo(artifact, ".jar"));
+        sb.append(subPathInMavenRepo(artifact, extension));
         return sb.toString();
     }
 

--- a/src/test/java/fr/jmini/utils/ecentral/ECentralTaskTest.java
+++ b/src/test/java/fr/jmini/utils/ecentral/ECentralTaskTest.java
@@ -178,8 +178,16 @@ class ECentralTaskTest {
     void testComputeMavenCentralUrl() throws Exception {
         MavenArtifact a = new MavenArtifact("org.eclipse.platform", "org.eclipse.ant.core", "3.5.600");
         assertThat(ECentralTask.computeMavenCentralUrl(a))
-                .as("url in maven centraal")
+                .as("url of the jar in maven central")
                 .isEqualTo("https://repo1.maven.org/maven2/org/eclipse/platform/org.eclipse.ant.core/3.5.600/org.eclipse.ant.core-3.5.600.jar");
+
+        assertThat(ECentralTask.computeMavenCentralUrl(a, ".pom"))
+                .as("url of the pom in maven central")
+                .isEqualTo("https://repo1.maven.org/maven2/org/eclipse/platform/org.eclipse.ant.core/3.5.600/org.eclipse.ant.core-3.5.600.pom");
+
+        assertThat(ECentralTask.computeMavenCentralUrl(a, ".jar.asc"))
+                .as("url of the armored ASCII file of the jar in maven central")
+                .isEqualTo("https://repo1.maven.org/maven2/org/eclipse/platform/org.eclipse.ant.core/3.5.600/org.eclipse.ant.core-3.5.600.jar.asc");
 
     }
 


### PR DESCRIPTION
Add a parameter to `computeMavenCentralUrl(..)` to be able to locate other files than `*.jar`