### PR TITLE
Gradle example improvements

### DIFF
--- a/usage-examples/jdt-gradle-example/build.gradle
+++ b/usage-examples/jdt-gradle-example/build.gradle
@@ -8,6 +8,8 @@ wrapper {
 }
 
 java {
+    withJavadocJar()
+    withSourcesJar()
     toolchain {
         languageVersion = JavaLanguageVersion.of(8)
     }
@@ -24,16 +26,6 @@ repositories {
     mavenCentral()
 }
 //end::repositories[]
-
-task sourcesJar(type: Jar, dependsOn: classes) {
-    classifier = 'sources'
-    from sourceSets.main.allSource
-}
-
-task javadocJar(type: Jar) {
-    from javadoc
-    classifier = 'javadoc'
-}
 
 //tag::dependencies[]
 dependencies {

--- a/usage-examples/jdt-gradle-example/build.gradle
+++ b/usage-examples/jdt-gradle-example/build.gradle
@@ -17,6 +17,9 @@ java {
 repositories {
     maven {
         url 'https://raw.githubusercontent.com/jmini/ecentral/HEAD/repo'
+        content {
+            includeGroup 'fr.jmini.ecentral'
+        }
     }
     mavenCentral()
 }


### PR DESCRIPTION
* Add a filter on the repository
https://docs.gradle.org/current/userguide/declaring_repositories.html#sec:declaring-repository-filter

* Use the new notation for sources jar and javadoc jar
https://docs.gradle.org/current/userguide/java_plugin.html#sec:java-extension